### PR TITLE
Update sora2_types.json

### DIFF
--- a/sora2_types.json
+++ b/sora2_types.json
@@ -1,5 +1,6 @@
 {
   "runtime_id": 1,
+  "types": {},
   "versioning": [
     {
       "runtime_range": [


### PR DESCRIPTION
empty root types to comply with fearless-utils-ios